### PR TITLE
More flexible JSON parsing after format change in the ARD Mediathek.

### DIFF
--- a/download_mediathek.sh
+++ b/download_mediathek.sh
@@ -72,7 +72,7 @@ fi
 
 JSON_URL="${MEDIATHEK_URL}${MEDIAID}${MEDIATHEK_POSTFIX}"
 #echo 'JSON: '${JSON_URL}
-DOWNLOADURL=$(curl --silent $JSON_URL | jq -r '._mediaArray[1]._mediaStreamArray['$QUALITY']._stream')
+DOWNLOADURL=$(curl --silent $JSON_URL | jq -c '._mediaArray[1]._mediaStreamArray[]' test.json | grep \"_quality\":$QUALITY | jq -r '._stream')
 #echo 'Downloading: ' ${DOWNLOADURL}
 
 if test -z "$DOWNLOADURL" ; then

--- a/download_mediathek.sh
+++ b/download_mediathek.sh
@@ -72,7 +72,7 @@ fi
 
 JSON_URL="${MEDIATHEK_URL}${MEDIAID}${MEDIATHEK_POSTFIX}"
 #echo 'JSON: '${JSON_URL}
-DOWNLOADURL=$(curl --silent $JSON_URL | jq -c '._mediaArray[1]._mediaStreamArray[]' test.json | grep \"_quality\":$QUALITY | jq -r '._stream')
+DOWNLOADURL=$(curl --silent $JSON_URL | jq -c '._mediaArray[1]._mediaStreamArray[]' | grep \"_quality\":$QUALITY | jq -r '._stream')
 #echo 'Downloading: ' ${DOWNLOADURL}
 
 if test -z "$DOWNLOADURL" ; then


### PR DESCRIPTION
Since a couple of days ago, the JSON of the ARD Mediathek does not necessarily contain all possible qualities, making a positional access to the "_stream" address error-prone. This fix introduces an intermediate grep step that filters all existing JSON mp4 stream objects for the requested "_quality" value and then adds another jq call to get its stream address. It e.g. worked in a test with the default quality value of three.
